### PR TITLE
Catch the exception thrown if a DocBlock cannot be read.

### DIFF
--- a/src/Parser/Visitor/Required/NameResolver.php
+++ b/src/Parser/Visitor/Required/NameResolver.php
@@ -26,6 +26,7 @@
 namespace PhpDA\Parser\Visitor\Required;
 
 use phpDocumentor\Reflection\DocBlock;
+use PhpParser\Error;
 use PhpParser\Node;
 use PhpParser\NodeVisitor\NameResolver as PhpParserNameResolver;
 
@@ -57,10 +58,8 @@ class NameResolver extends PhpParserNameResolver
                         $node->setAttribute(self::TAG_NAMES_ATTRIBUTE, $tagNames);
                     }
             }
-        } catch(\InvalidArgumentException $e) {
-            //The Doc Block could not be parsed. We log the problem and keep going.
-            //This can happen e.g. if in the Doc block there is an "@" with a space character directly afterwards.
-            error_log($e->getMessage()." ".$e->getTraceAsString());
+        } catch(\Exception $e) {
+            throw new Error($e->getMessage(), $node->getLine());
         }
     }
 

--- a/tests/PhpDATest/Parser/Visitor/Required/NameResolverTest.php
+++ b/tests/PhpDATest/Parser/Visitor/Required/NameResolverTest.php
@@ -127,4 +127,18 @@ class NameResolverTest extends \PHPUnit_Framework_TestCase
 
         $this->fixture->enterNode($node->shouldIgnoreMissing());
     }
+
+    /**
+     * @expectedException \PhpParser\Error
+     */
+    public function testInvalidDocBlock()
+    {
+        $docBlock = '/** @ A Whitespace after "at" causes PhpDocumentor to throw an exception. It should be converted to a PhpParser\Error */';
+        $comment = \Mockery::mock('PhpParser\Comment\Doc');
+        $comment->shouldReceive('getText')->andReturn($docBlock);
+        $node = \Mockery::mock('PhpParser\Node');
+        $node->shouldReceive('getDocComment')->once()->andReturn($comment);
+
+        $this->fixture->enterNode($node->shouldIgnoreMissing());
+    }
 }


### PR DESCRIPTION
If
- The TagVisitor was active
- Any PhpDoc of a method contained "@" with a white space right after it.

An \InvalidArgumentException was thrown and not catched which broke the whole process of building dependencies.

The solution in this pull request tries to ignore the Exception as it is a problem of the phpDocumentor library. At the same time it logs the occurrence. This looks quite ugly if used in the command line though. Do you have any suggestions on that?
