### PR TITLE
Use verbosity constant in tests

### DIFF
--- a/tests/PhpDATest/Command/Strategy/CallTest.php
+++ b/tests/PhpDATest/Command/Strategy/CallTest.php
@@ -26,6 +26,7 @@
 namespace PhpDATest\Command\Strategy;
 
 use PhpDA\Command\Strategy\Call;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class CallTest extends \PHPUnit_Framework_TestCase
 {
@@ -118,7 +119,7 @@ class CallTest extends \PHPUnit_Framework_TestCase
         $file = \Mockery::mock('Symfony\Component\Finder\SplFileInfo');
         $file->shouldReceive('getRealPath')->once()->andReturn('anypath');
 
-        $this->output->shouldReceive('getVerbosity')->andReturn(3);
+        $this->output->shouldReceive('getVerbosity')->andReturn(OutputInterface::VERBOSITY_VERBOSE);
         $this->finder->shouldReceive('count')->once()->andReturn(6000);
         $this->finder->shouldReceive('getIterator')->andReturn(array($file));
         $this->fixture->setOptions(
@@ -166,7 +167,7 @@ class CallTest extends \PHPUnit_Framework_TestCase
         $file = \Mockery::mock('Symfony\Component\Finder\SplFileInfo');
         $file->shouldReceive('getRealPath')->once()->andReturn('anypath');
 
-        $this->output->shouldReceive('getVerbosity')->andReturn(3);
+        $this->output->shouldReceive('getVerbosity')->andReturn(OutputInterface::VERBOSITY_VERBOSE);
         $this->finder->shouldReceive('count')->once()->andReturn(6000);
         $this->finder->shouldReceive('getIterator')->andReturn(array($file));
         $this->fixture->setOptions(

--- a/tests/PhpDATest/Command/Strategy/InheritanceTest.php
+++ b/tests/PhpDATest/Command/Strategy/InheritanceTest.php
@@ -26,6 +26,7 @@
 namespace PhpDATest\Command\Strategy;
 
 use PhpDA\Command\Strategy\Inheritance;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class InheritanceTest extends \PHPUnit_Framework_TestCase
 {
@@ -113,7 +114,7 @@ class InheritanceTest extends \PHPUnit_Framework_TestCase
         $file = \Mockery::mock('Symfony\Component\Finder\SplFileInfo');
         $file->shouldReceive('getRealPath')->once()->andReturn('anypath');
 
-        $this->output->shouldReceive('getVerbosity')->andReturn(3);
+        $this->output->shouldReceive('getVerbosity')->andReturn(OutputInterface::VERBOSITY_VERBOSE);
         $this->finder->shouldReceive('count')->once()->andReturn(6000);
         $this->finder->shouldReceive('getIterator')->andReturn(array($file));
         $this->fixture->setOptions(array('output' => $this->output, 'config' => $this->config));

--- a/tests/PhpDATest/Command/Strategy/UsageTest.php
+++ b/tests/PhpDATest/Command/Strategy/UsageTest.php
@@ -26,6 +26,7 @@
 namespace PhpDATest\Command\Strategy;
 
 use PhpDA\Command\Strategy\Usage;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class UsageTest extends \PHPUnit_Framework_TestCase
 {
@@ -112,7 +113,7 @@ class UsageTest extends \PHPUnit_Framework_TestCase
         $file = \Mockery::mock('Symfony\Component\Finder\SplFileInfo');
         $file->shouldReceive('getRealPath')->once()->andReturn('anypath');
 
-        $this->output->shouldReceive('getVerbosity')->andReturn(3);
+        $this->output->shouldReceive('getVerbosity')->andReturn(OutputInterface::VERBOSITY_VERBOSE);
         $this->finder->shouldReceive('count')->once()->andReturn(6000);
         $this->finder->shouldReceive('getIterator')->andReturn(array($file));
         $this->fixture->setOptions(array('output' => $this->output, 'config' => $this->config));


### PR DESCRIPTION
There were hardcoded "3" there. Also many copy-paste. May be it's better move to abstract PhpDABaseTest?