### PR TITLE
Add type renamer visitor with example

### DIFF
--- a/phpda.yml.dist
+++ b/phpda.yml.dist
@@ -16,8 +16,13 @@ visitor:
 #  - PhpDA\Parser\Visitor\UnsupportedGlobalCollector
 #  - PhpDA\Parser\Visitor\NamespacedStringCollector
 #  - PhpDA\Parser\Visitor\IocContainerAccessorCollector
+#  - PhpDA\Parser\Visitor\TypeRenamer
 visitorOptions:
   PhpDA\Parser\Visitor\Required\DeclaredNamespaceCollector: {minDepth: 2, sliceLength: 2}
   PhpDA\Parser\Visitor\Required\MetaNamespaceCollector: {minDepth: 2, sliceLength: 2}
   PhpDA\Parser\Visitor\Required\UsedNamespaceCollector: {minDepth: 2, sliceLength: 2}
   PhpDA\Parser\Visitor\TagCollector: {minDepth: 2, sliceLength: 2}
+#  PhpDA\Parser\Visitor\TypeRenamer:
+#    rename:
+#      PhpDA\Writer\Strategy\Svg: S
+#      Fully\Qualified\Class\Name\To\NamespaceFilter: Something\Short

--- a/src/Parser/Visitor/TypeRenamer.php
+++ b/src/Parser/Visitor/TypeRenamer.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright © 2016 Alexander Ustimenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+namespace PhpDA\Parser\Visitor;
+
+use PhpDA\Parser\Visitor\AbstractVisitor;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Param;
+
+/**
+ * Renames some long-namespaced classes into shorter versions
+ *
+ * @see phpda.yml.dist for example config
+ */
+class TypeRenamer extends AbstractVisitor
+{
+
+    private $rename = array();
+
+    public function setOptions(array $options)
+    {
+        parent::setOptions($options);
+        if (isset($options['rename']) && is_array($options['rename'])) {
+            $this->rename = $options['rename'];
+        }
+    }
+
+    public function enterNode(Node $node)
+    {
+        if (empty($this->rename)) {
+            return;
+        }
+        if (isset($node->namespacedName)) {
+            $this->rename($node->namespacedName);
+        }
+        if (isset($node->extends)) {
+            $this->rename($node->extends);
+        }
+        if (isset($node->class)) {
+            $this->rename($node->class);
+        }
+        if ($node instanceof Class_) {
+            $node->name = $this->renameString($node->name);
+            foreach ($node->implements as $name) {
+                $this->rename($name);
+            }
+        }
+        if ($node instanceof Param) {
+            $this->rename($node->type);
+        }
+    }
+
+    private function rename($name)
+    {
+        if ($name instanceof Node\Name) {
+            $name->set($this->renameString($name->toString()));
+        }
+    }
+
+    private function renameString($name)
+    {
+        return str_replace(array_keys($this->rename), array_values($this->rename), $name);;
+    }
+}

--- a/tests/PhpDATest/Parser/Visitor/TypeRenamerTest.php
+++ b/tests/PhpDATest/Parser/Visitor/TypeRenamerTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright © 2016 Alexander Ustimenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+namespace PhpDATest\Parser\Visitor;
+
+use PhpDA\Parser\Visitor\TypeRenamer;
+use PhpParser\Parser;
+use PhpParser\Lexer\Emulative;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\Node\Stmt\Class_;
+
+class TypeRenamerTest extends \PHPUnit_Framework_TestCase
+{
+
+    /** @var TypeRenamer */
+    protected $fixture;
+
+    protected function setUp()
+    {
+        $this->fixture = new TypeRenamer();
+    }
+
+    public function testRenameOccursWithSettings()
+    {
+        $this->fixture->setOptions(array(
+            'rename' => array(
+                'Test' => 'Production'
+            )
+        ));
+        $nodes = $this->traverseSelf();
+        /** @var Class_ */
+        $class = end($nodes[0]->stmts);
+
+        $this->assertContains('Production', $class->name);
+    }
+
+    public function testRenameNotOccursWithoutSettings()
+    {
+        $nodes = $this->traverseSelf();
+        /** @var Class_ */
+        $class = end($nodes[0]->stmts);
+        $this->assertNotContains('Production', $class->name);
+    }
+
+    private function traverseSelf()
+    {
+        $lexer = new Emulative(array(
+            'usedAttributes' => array(
+                'startLine',
+                'endLine',
+                'startFilePos',
+                'endFilePos'
+            )
+        ));
+        $parser = new Parser($lexer);
+
+        $code = file_get_contents(__FILE__);
+        $nodes = $parser->parse($code);
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new NameResolver());
+        $traverser->addVisitor($this->fixture);
+        $traverser->traverse($nodes);
+
+        return $nodes;
+    }
+}


### PR DESCRIPTION
Valuable when you have very long namespaced names like "Fully\Qualified\Class\Name\To\NamespaceFilter" and you want to see them on diagrams like "Something\Short"

With example added.