### PR TITLE
Invalid config settings should throw an exception

### DIFF
--- a/src/Command/Config.php
+++ b/src/Command/Config.php
@@ -77,9 +77,12 @@ class Config
     public function __construct(array $config)
     {
         foreach ($config as $property => $value) {
-            if (property_exists($this, $property)) {
-                $this->$property = $value;
+            if (!property_exists($this, $property)) {
+                throw new \InvalidArgumentException(
+                    'Invalid configuration setting: '.$property
+                );
             }
+            $this->$property = $value;
         }
     }
 

--- a/tests/PhpDATest/Command/ConfigTest.php
+++ b/tests/PhpDATest/Command/ConfigTest.php
@@ -72,6 +72,12 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('inheritance', $config->getMode());
     }
 
+    public function testInvalidSetting()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        new Config(array('foo' => 1));
+    }
+
     public function testInvalidMode()
     {
         $this->setExpectedException('InvalidArgumentException');


### PR DESCRIPTION
Hi, I think that PHPDA should warn the user about invalid configuration.

What do you think?