### PR TITLE
Allow to use relative path in the config yaml

### DIFF
--- a/src/Command/Analyze.php
+++ b/src/Command/Analyze.php
@@ -137,6 +137,8 @@ class Analyze extends Command
             throw new \InvalidArgumentException('Configuration is invalid');
         }
 
+        $config['source'] = !isset($config['source']) ?: $this->generateAbsolutePathFrom($config['source']);
+        $config['target'] = !isset($config['target']) ?: $this->generateAbsolutePathFrom($config['target']);
         $config = array_merge($config, array_filter($input->getOptions()));
 
         if (isset($config['ignore']) && !is_array($config['ignore'])) {
@@ -146,6 +148,30 @@ class Analyze extends Command
         return new Config($config);
     }
 
+    /**
+     * From phpunit https://goo.gl/t6PuXz
+     * @param string $path
+     * @return bool
+     */
+    public function generateAbsolutePathFrom($path)
+    {
+        $path = trim($path);
+        if ($path[0] === '/') {
+            return $path;
+        }
+        if (defined('PHP_WINDOWS_VERSION_BUILD') &&
+            ($path[0] === '\\' ||
+            (strlen($path) >= 3 && preg_match('#^[A-Z]\:[/\\\]#i', substr($path, 0, 3))))) {
+            return $path;
+        }
+        if (strpos($path, '://') !== false) {
+            return $path;
+        }
+        $file = dirname($this->configFilePath) . DIRECTORY_SEPARATOR . $path;
+
+        return $file;
+    }
+    
     /**
      * @param string $type
      * @param array  $options

--- a/tests/PhpDATest/Command/AnalyzeTest.php
+++ b/tests/PhpDATest/Command/AnalyzeTest.php
@@ -117,7 +117,7 @@ class AnalyzeTest extends \PHPUnit_Framework_TestCase
 
         $configPath = __DIR__ . '/Stub/config.txt';
         $config = array('mode' => 'call', 'source' => '.', 'ignore' => 'dir1, dir2,dir3');
-        $options = array('mode' => 'inheritance', 'source' => '.');
+        $options = array('mode' => 'inheritance', 'source' => '/tmp/StubDir');
 
         $input->shouldReceive('getArgument')->with('config')->once()->andReturn($configPath);
         $input->shouldReceive('getOptions')->once()->andReturn($options);
@@ -132,7 +132,7 @@ class AnalyzeTest extends \PHPUnit_Framework_TestCase
                 $testcase->assertSame($output, $options['output']);
                 /** @var Config $config */
                 $config = $options['config'];
-                $testcase->assertSame('.', $config->getSource());
+                $testcase->assertSame('/tmp/StubDir', $config->getSource());
                 $testcase->assertSame(array('dir1', 'dir2', 'dir3'), $config->getIgnore());
                 $strategy = \Mockery::mock('PhpDA\Command\Strategy\StrategyInterface');
                 $strategy->shouldReceive('execute')->once()->andReturn(true);


### PR DESCRIPTION
Hi, I have placed a yml in one of my projects root and I have set a relative link for the "source" and "target" configurations.
However, I did not started phpda from the root of my project and I got error because of it.

I think that phpda should read relative path from the location of the config yml file.
I don't know if my proposal is good enough as I'm still looking to get familiar with phpda (I don't like it that much) but I wanted to ear from you before going any further.

I hope you can help me here. :)

