### PR TITLE
Add support to build phar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 composer.lock
 vendor
+.idea
+phpda.phar

--- a/box.json
+++ b/box.json
@@ -1,0 +1,27 @@
+{
+  "chmod": "0755",
+  "directories": ["src"],
+  "files": [
+    "LICENSE",
+    "CHANGELOG.md",
+    "CODE_OF_CONDUCT.md",
+    "CONTRIBUTING.md",
+    "README.md",
+    "bin/phpda.php"
+  ],
+  "finder": [
+    {
+      "name": "*.php",
+      "exclude": [
+        "test",
+        "tests",
+        "Tests"
+      ],
+      "in": "vendor"
+    }
+  ],
+  "main": "bin/phpda",
+  "output": "phpda.phar",
+  "stub": true,
+  "web": false
+}

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,10 @@
     "issues": "https://github.com/mamuz/PhpDependencyAnalysis/issues",
     "source": "https://github.com/mamuz/PhpDependencyAnalysis"
   },
+  "scripts": {
+    "test": "phpunit",
+    "build": "box build -v"
+  },
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {


### PR DESCRIPTION
Hi,
I configured it that you can build a phar file easily.
You have to install box2 (https://github.com/box-project/box2) and run "composer build"
Cheers