### PR TITLE
Allow newer version of nikic/php-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "psr/log": "~1.0",
-        "nikic/php-parser": "~2.0",
+        "nikic/php-parser": "~2.0|~3.0",
         "clue/graph": "~0.8",
         "graphp/algorithms": "~0.8.1",
         "graphp/graphviz": "~0.2.0",


### PR DESCRIPTION
Allow newer version of nikic/php-parser. This helped me with conflicts and it seems to also have fixed a problem with parsing nullable types in php 7.2